### PR TITLE
Fix crash with infinity containers

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -137,7 +137,7 @@ local function get_active_items(entity)
         return {}
     end
     local active_items = {}
-    if entity.filter_slot_count > 0 then
+    if entity.filter_slot_count > 0 and entity.type ~= "infinity-container" then
         for i = 1, entity.filter_slot_count do ---@type uint
             table.insert(active_items, entity.get_filter(i))
         end


### PR DESCRIPTION
Factorio handles infinity containers a bit weirdly.  Skip trying to build a filter selection for them.

This should fix #2 Tested locally with 1.1.89, infinity chest, and infinity loaders.