### PR TITLE
Support for logistic storage chests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 0.1.9
 Date: ????
   Changes:
+    - Added support for logistic storage chests
 ---------------------------------------------------------------------------------------------------
 Version: 0.1.8
 Date: 2023-10-03


### PR DESCRIPTION
Added support for logistic storage chests. Iterates inserters in an area which serve this chest, and finds the filters relevant for the inserter's pickup and drop points.

Distance to search for inserters is hard-coded to 3, as that should be good enough for 99% of cases, including Bob's inserters. This could be a settings option.