### PR TITLE
do not show non-item signals because they otherwise crash when selected

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 Version: 0.1.9
 Date: ????
-  Changes:
+  Bugfixes:
+    - Fixed crash when selecting a fluid from a signal as a filter by no longer showing non-item signals from the circuit network
 ---------------------------------------------------------------------------------------------------
 Version: 0.1.8
 Date: 2023-10-03

--- a/control.lua
+++ b/control.lua
@@ -266,7 +266,7 @@ local function add_items_circuit(entity, items)
             if signals then
                 for _, signal in pairs(signals) do
                     local signal_id = signal.signal
-                    if signal_id.name then
+                    if signal_id.name and signal_id.type == "item" then
                         items[signal_id.name] = signal_id.type .. "/" .. signal_id.name
                     end
                 end


### PR DESCRIPTION
Fixes https://mods.factorio.com/mod/FilterHelper/discussion/653b05104cf4fd71cb3d86d6

I tested it myself before this change and confirmed the crash when selecting a fluid circuit signal. And confirmed after this change that the fluid circuit signal is not available to choose.