### PR TITLE
Support for logistic storage chests (reopened)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 Version: 0.1.9
 Date: ????
+  Changes:
+    - Added support for logistic storage chests
   Bugfixes:
     - Fixed crash when selecting a fluid from a signal as a filter by no longer showing non-item signals from the circuit network
 ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Added support for logistic storage chests. Iterates inserters in an area which serve this chest, and finds the filters relevant for the inserter's pickup and drop points.

Distance to search for inserters is hard-coded to 3, as that should be good enough for 99% of cases, including Bob's inserters. This could be a settings option.
