### PR TITLE
Add spoiled ingredients to assembler output inserters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 0.2.13
 Date: ????
   Changes:
+    - For assembling machine output inserters, add shortcuts for spoiled ingredients
 ---------------------------------------------------------------------------------------------------
 Version: 0.2.12
 Date: 2025-01-11

--- a/control.lua
+++ b/control.lua
@@ -251,6 +251,14 @@ function FilterHelper.add_items_pickup_target_entity(target, items)
                         fh_util.add_item_to_table(items, product, quality)
                     end
                 end
+                for _, ingredient in pairs(recipe.ingredients) do
+                    if ingredient.type == "item" then
+                        local spoiled_ingredient = prototypes.item[ingredient.name].spoil_result
+                        if spoiled_ingredient ~= nil then
+                            fh_util.add_item_to_table(items, spoiled_ingredient, quality)
+                        end
+                    end
+                end
                 if not has_quality then
                     break
                 end


### PR DESCRIPTION
See https://mods.factorio.com/mod/FilterHelper/discussion/678a7f7564d8aea6f5d6a516

This only adds the extra shortcuts for the output inserter, it doesn't remove shortcuts from the input inserter.