### PR TITLE
Removed on tick handler, GUI update bug was fixed in 2.0

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -640,18 +640,5 @@ script.on_event(defines.events.on_gui_click, function(event)
     end
 end)
 
--- we need to close the ui on click and open it a tick later
--- to visually update the filter ui
--- if https://forums.factorio.com/viewtopic.php?f=7&t=106300 gets addressed,
--- this close/reopen GUI business can be removed
-script.on_event(defines.events.on_tick, function(event)
-    for _, player in pairs(game.players) do
-        local player_global = get_player_global(player.index)
-        if player_global then
-            update_ui(player_global, event.tick % 60 == 0)
-        end
-    end
-end)
-
 -- TODO options for what things are considered. Chests, transport lines, etc
 -- TODO recently used section


### PR DESCRIPTION
This handler is just eating away at UPS since the filter GUI update bug was fixed in 2.0. Figured it isn't necessary anymore and removed it.